### PR TITLE
#151629710 Create separate dashboard for deactivated gym users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,5 @@ target/
 wger/core/static/bower_components
 node_modules
 
-# Local settings
-wger/settings.py
-
 # Migrations
 migrations/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*.DS_Store
 
 # C extensions
 *.so
@@ -64,3 +65,9 @@ target/
 # External Libraries
 wger/core/static/bower_components
 node_modules
+
+# Local settings
+wger/settings.py
+
+# Migrations
+migrations/

--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -229,7 +229,8 @@
                                             <li><a href="{% url 'core:weight-unit:list' %}">{% trans "Weight units" %} </a></li>
                                         {% endif %}
                                         {% if perms.gym.manage_gyms %}
-                                            <li><a href="{% url 'core:user:list' %}">{% trans "User list" %} </a></li>
+                                            <li><a href="{% url 'core:user:list' %}">{% trans "Active Users" %} </a></li>
+                                            <li><a href="{% url 'core:user:inactive_list' %}">{% trans "Inactive users" %} </a></li>
                                             <li><a href="{% url 'gym:gym:list' %}">{% trans "Gyms" %} </a></li>
                                         {% endif  %}
 

--- a/wger/core/templates/user/list.html
+++ b/wger/core/templates/user/list.html
@@ -1,7 +1,13 @@
 {% extends "base.html" %}
 {% load i18n staticfiles wger_extras django_bootstrap_breadcrumbs %}
 
-{% block title %}{% trans "User list" %}{% endblock %}
+{% block title %}
+    {% if user_type %}
+        {% trans "Active Users" %}
+    {% else %}
+        {% trans "Inactive Users" %}
+    {% endif %}
+{% endblock %}
 
 
 {% block content %}

--- a/wger/core/tests/test_user.py
+++ b/wger/core/tests/test_user.py
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 
-from django.contrib.auth.models import User, UserManager
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse, reverse_lazy
 
 from wger.core.tests.base_testcase import (WorkoutManagerTestCase,

--- a/wger/core/tests/test_user.py
+++ b/wger/core/tests/test_user.py
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, UserManager
 from django.core.urlresolvers import reverse, reverse_lazy
 
 from wger.core.tests.base_testcase import (WorkoutManagerTestCase,
@@ -164,6 +164,27 @@ class UserListTestCase(WorkoutManagerAccessTestCase):
     user_success = ('admin', 'general_manager1', 'general_manager2')
     user_fail = ('member1', 'member2', 'manager1', 'manager2', 'manager3',
                  'trainer2', 'trainer3', 'trainer4')
+
+
+    def test_active_inactive_user_view(self):
+        '''
+        Login admin. Create active and inactive users. Ensure active user
+        is on the list page and that inactive user is on the inactive_list
+        page.
+        '''
+        self.user_login('admin')
+        active_user = User.objects.get(pk=14)
+        inactive_user = User.objects.get(pk=13)
+        inactive_user.is_active = False
+        inactive_user.save()
+        self.assertTrue(active_user.is_active)
+        self.assertFalse(inactive_user.is_active)
+        get_active_users = self.client.get(reverse(self.url))
+        self.assertContains(get_active_users, active_user.username, status_code=200)
+        self.assertNotContains(get_active_users, inactive_user.username, status_code=200)
+        get_inactive_users = self.client.get(reverse('core:user:inactive_list'))
+        self.assertContains(get_inactive_users, inactive_user.username, status_code=200)
+        self.assertNotContains(get_inactive_users, active_user.username, status_code=200)
 
 
 class UserDetailPageTestCase(WorkoutManagerAccessTestCase):

--- a/wger/core/tests/test_user.py
+++ b/wger/core/tests/test_user.py
@@ -173,8 +173,8 @@ class UserListTestCase(WorkoutManagerAccessTestCase):
         page.
         '''
         self.user_login('admin')
-        active_user = User.objects.get(pk=14)
-        inactive_user = User.objects.get(pk=13)
+        active_user = User.objects.create_user(username='active_user_example1')
+        inactive_user = User.objects.create_user(username='inactive_user_example2')
         inactive_user.is_active = False
         inactive_user.save()
         self.assertTrue(active_user.is_active)

--- a/wger/core/urls.py
+++ b/wger/core/urls.py
@@ -60,7 +60,12 @@ patterns_user = [
     url(r'^(?P<pk>\d+)/overview',
         user.UserDetailView.as_view(),
         name='overview'),
-    url(r'^list', user.UserListView.as_view(), name='list'),
+    url(r'^list',
+        user.UserListView.as_view(),
+        name='list'),
+    url(r'^inactive_list',
+        user.UserListView.as_view(userType=False),
+        name='inactive_list'),
 
     # Password reset is implemented by Django,
     # no need to cook our own soup here

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -508,13 +508,13 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
         '''
         Return a list with the users, not really a queryset.
         '''
-        out = {'admins': [],
+        user_list = {'admins': [],
                'members': []}
         for user in User.objects.select_related('usercache',
                                                 'userprofile__gym').filter(is_active=self.userType):
-            out['members'].append({'obj': user,
+            user_list['members'].append({'obj': user,
                                    'last_log': user.usercache.last_activity})
-        return out
+        return user_list
 
     def get_context_data(self, **kwargs):
         '''

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -502,20 +502,18 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     model = User
     permission_required = ('gym.manage_gyms', )
     template_name = 'user/list.html'
+    userType = True
 
     def get_queryset(self):
         '''
         Return a list with the users, not really a queryset.
         '''
-        out = {'admins': [], 'members': []}
-
-        for u in User.objects.select_related('usercache',
-                                             'userprofile__gym').all():
-            out['members'].append({
-                'obj': u,
-                'last_log': u.usercache.last_activity
-            })
-
+        out = {'admins': [],
+               'members': []}
+        for user in User.objects.select_related('usercache',
+                                                'userprofile__gym').filter(is_active=self.userType):
+            out['members'].append({'obj': user,
+                                   'last_log': user.usercache.last_activity})
         return out
 
     def get_context_data(self, **kwargs):
@@ -524,14 +522,11 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
         '''
         context = super(UserListView, self).get_context_data(**kwargs)
         context['show_gym'] = True
-        context['user_table'] = {
-            'keys':
-            [_('ID'),
-             _('Username'),
-             _('Name'),
-             _('Last activity'),
-             _('Gym')],
-            'users':
-            context['object_list']['members']
-        }
+        context['user_table'] = {'keys': [_('ID'),
+                                          _('Username'),
+                                          _('Name'),
+                                          _('Last activity'),
+                                          _('Gym')],
+                                 'users': context['object_list']['members']}
+        context['user_type'] = self.userType,
         return context

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -528,5 +528,5 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
                                           _('Last activity'),
                                           _('Gym')],
                                  'users': context['object_list']['members']}
-        context['user_type'] = self.userType,
+        context['user_type'] = self.userType
         return context

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -13,10 +13,17 @@ $(document).ready( function () {
     });
 });
 </script>
+{% if user_type %}
+<style>
+    #table-header{
+        background-color: #00FF00
+    }
+</style>
+ {% endif %}
 
 <table class="table table-hover" id="main_member_list">
 <thead>
-<tr>
+<tr id="table-header">
     {% for key in user_table.keys %}
         <th>{{ key }}</th>
     {% endfor %}


### PR DESCRIPTION
#### What does this PR do?
This PR separates the dashboard for the user list into a separate dashboard for active and inactive users. 
#### Description of Task to be completed?
Originally a list of all users is shown while navigating to the user list. Each user on the list has the quality of either being active or inactive as his or her status. To view such status you have to click onto the specific user. This PR is meant to separate the two instances into two views. One view shows all the active users, while the other view shows all the inactive users.
#### How should this be manually tested?
The test for this PR can simply be run by the following command:
`python manage.py test wger.core.tests.test_user.UserListTestCase.test_active_inactive_user_view`
However, if it is desired to test all run the command line: `python manage.py test`
#### What are the relevant pivotal tracker stories?
#151629710
#### Screenshots (if appropriate)
Active User dashboard
![image](https://user-images.githubusercontent.com/29925144/31431836-72414fba-ae7d-11e7-8cea-135c54607f53.png)

Inactive User dashboard
![image](https://user-images.githubusercontent.com/29925144/31384871-8433935e-adc9-11e7-8977-bfb1935213dc.png)


