### PR TITLE
#151629711 Cache Calculated Nutrition Information for User's Nutrition Plans

### DIFF
--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -18,3 +18,4 @@
 from wger import get_version
 
 VERSION = get_version()
+default_app_config = 'wger.nutrition.apps.NutritionConfig'

--- a/wger/nutrition/apps.py
+++ b/wger/nutrition/apps.py
@@ -1,0 +1,14 @@
+'''A module that imports the signals file into an instance of nutrition'''
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class NutritionConfig(AppConfig):
+    '''A class that imports the signals file to be passed onto the instance
+    of the nutrition object being called.
+    '''
+    name = "wger.nutrition"
+    verbose_name = _('nutrition')
+
+    def ready(self):
+        import wger.nutrition.signals

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -117,56 +117,60 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {
-            'total': {
-                'energy': 0,
-                'protein': 0,
-                'carbohydrates': 0,
-                'carbohydrates_sugar': 0,
-                'fat': 0,
-                'fat_saturated': 0,
-                'fibres': 0,
-                'sodium': 0
-            },
-            'percent': {
-                'protein': 0,
-                'carbohydrates': 0,
-                'fat': 0
-            },
-            'per_kg': {
-                'protein': 0,
-                'carbohydrates': 0,
-                'fat': 0
-            },
-        }
+        result = cache.get(cache_mapper.get_nutritional_info(self.pk))
+        if not result:
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {
+                'total': {
+                    'energy': 0,
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'carbohydrates_sugar': 0,
+                    'fat': 0,
+                    'fat_saturated': 0,
+                    'fibres': 0,
+                    'sodium': 0
+                },
+                'percent': {
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'fat': 0
+                },
+                'per_kg': {
+                    'protein': 0,
+                    'carbohydrates': 0,
+                    'fat': 0
+                },
+            }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        energy = result['total']['energy']
+            energy = result['total']['energy']
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = result['total'][
-                    key] / weight_entry.weight
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][
+                        key] / weight_entry.weight
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+                    
+            cache.set(cache_mapper.get_nutritional_info(self.pk), result)
 
         return result
 

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,27 @@
+'''
+A module that is meant to delete cache for nutritional_info once
+any changes that will affect the contained calculated information is made.
+'''
+from django.core.cache import cache
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.utils.cache import cache_mapper
+
+SIGNALS_RECEIVED = [post_save, post_delete]
+@receiver(SIGNALS_RECEIVED, sender=NutritionPlan)
+@receiver(SIGNALS_RECEIVED, sender=Meal)
+@receiver(SIGNALS_RECEIVED, sender=MealItem)
+
+def cache_deletion_on_change(sender, instance, **kwargs):
+    '''
+    Delete cache data for a particular nutrion plan once an add, edit
+    or delete occurs on Meal, MealItem classes and the NutritionPlan class.
+    '''
+    if sender == Meal:
+        nutrition_plan_id = instance.plan_id
+    elif sender == MealItem:
+        nutrition_plan_id = Meal.objects.get(id=instance.meal_id).plan_id
+    else:
+        nutrition_plan_id = instance.id
+    cache.delete(cache_mapper.get_nutritional_info(nutrition_plan_id))

--- a/wger/nutrition/tests/test_nutrition_info.py
+++ b/wger/nutrition/tests/test_nutrition_info.py
@@ -1,0 +1,94 @@
+'''
+Tests the cache operation for calculated nutrition information
+'''
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.utils.cache import cache_mapper
+from wger.core.models import Language
+
+class NutritionaCacheTestCase(WorkoutManagerTestCase):
+    '''
+    Test cache is deleted once data for calculation of the nutritonal information
+    changes. Data is derived from the Meal and Meal Item classes and stored to a
+    parent object of the NutritionPlan class
+    '''
+
+    def create_nutrition_plan(self):
+        '''
+        Create a nutrition plan and set dummy attributes that are required
+        Create meal and set dummy attributes that are required
+        Create meal item and set dummy attributes that are required
+        '''
+        nutrition_plan = NutritionPlan()
+        nutrition_plan.user = User.objects.create_user(username='example_user_1')
+        nutrition_plan.language = Language.objects.get(short_name="en")
+        nutrition_plan.save()
+        meal = Meal()
+        meal.plan = nutrition_plan
+        meal.order = 1
+        meal.save()
+        meal_item = MealItem()
+        meal_item.meal = meal
+        meal_item.amount = 1
+        meal_item.ingredient_id = 1
+        meal_item.order = 1
+        test_objects = [nutrition_plan, meal, meal_item]
+        return test_objects
+
+    def test_cache_setting(self):
+        '''
+        Test that a cache is set once the nutritional information is called
+        '''
+        nutrition_object = self.create_nutrition_plan()[0]
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_info(nutrition_object)))
+        nutrition_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_info(nutrition_object)))
+
+    def test_nutrition_save_delete(self):
+        '''
+        Test that the cache is deleted once a nutrition plan undergoes a save or
+        delete operation
+        '''
+        nutrition_object = self.create_nutrition_plan()[0]
+        nutrition_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_info(nutrition_object)))
+        nutrition_object.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_info(nutrition_object)))
+        nutrition_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_info(nutrition_object)))
+        nutrition_object.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_info(nutrition_object)))
+
+    def test_meal_save_delete(self):
+        '''
+        Test that the cache is deleted once a meal undergoes a save or delete operation
+        '''
+        test_object_list = self.create_nutrition_plan()
+        nutritional_object = test_object_list[0]
+        meal = test_object_list[1]
+        nutritional_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_info(nutritional_object)))
+        meal.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_info(nutritional_object)))
+        nutritional_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_info(nutritional_object)))
+        meal.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_info(nutritional_object)))
+
+    def test_meal_item_save_delete(self):
+        '''
+        Test that the cache is deleted once a meal item undergoes a save or delete operation
+        '''
+        test_object_list = self.create_nutrition_plan()
+        nutritional_object = test_object_list[0]
+        meal_item = test_object_list[2]
+        nutritional_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_info(nutritional_object)))
+        meal_item.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_info(nutritional_object)))
+        nutritional_object.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_info(nutritional_object)))
+        meal_item.delete()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_info(nutritional_object)))

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -66,6 +66,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
+    NUTRITIONAL_INFORMATION_REPRESENTATION = 'nutritional-information-representation-{0}'
 
     def get_pk(self, param):
         '''
@@ -107,6 +108,12 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_CANONICAL_REPRESENTATION.format(self.get_pk(param))
+
+    def get_nutritional_info(self, param):
+        '''
+        Return the nutritional information representation
+        '''
+        return self.NUTRITIONAL_INFORMATION_REPRESENTATION.format(self.get_pk(param))
 
     def get_workout_log_list(self, hash_value):
         '''


### PR DESCRIPTION
#### What does this PR do?
This pull request depicts the changes made to fulfill the story for caching nutrition information that is calculated for various nutrition plans.
#### Description of Task to be completed?
The task was to change the way in which calculated nutritional information for a particular nutritional plan was being rendered. The task was to cache data for nutritional information for each nutrition plan. The task further required that the cached data would be deleted appropriately in instances where the Meal or Meal Item, relevant to calculating the nutritional information, was added, edited or deleted. The task also required that when a Nutrition Plan was added or deleted that the cached data would be deleted appropriately. The deletion would later lead to the cache  being set with data that was up to date.
#### How should this be manually tested?
To run tests for this feature run the command `python manage.py test wger.nutrition.tests.test_nutrition_info`
You can also run the command `python manage.py test` to run all the tests for the application
#### What are the relevant pivotal tracker stories?
#151629711

