### PR TITLE
#151629724 Allow The User To Add Ingredients When Making A New Meal

### DIFF
--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -18,9 +18,10 @@ import logging
 
 from django import forms
 from django.utils.translation import ugettext as _
+from django.forms.models import inlineformset_factory
 from wger.core.models import UserProfile
 
-from wger.nutrition.models import (IngredientWeightUnit, Ingredient, MealItem)
+from wger.nutrition.models import (IngredientWeightUnit, Ingredient, MealItem, Meal)
 from wger.utils.widgets import Html5NumberInput
 
 logger = logging.getLogger(__name__)
@@ -131,9 +132,21 @@ class MealItemForm(forms.ModelForm):
             ingredient_id = kwargs['instance'].ingredient_id
 
         if kwargs.get('data'):
-            ingredient_id = kwargs['data']['ingredient']
+            try:
+                ingredient_id = kwargs['data']['ingredient']
+            except KeyError:
+                ingredient_id = kwargs['data']['mealitem_set-0-ingredient']
 
         # Filter the available ingredients
         if ingredient_id:
             self.fields['weight_unit'].queryset = \
                 IngredientWeightUnit.objects.filter(ingredient_id=ingredient_id)
+
+MealItemFormSet = inlineformset_factory(
+    Meal,
+    MealItem,
+    fields='__all__',
+    form=MealItemForm,
+    extra=1,
+    can_delete=False
+)

--- a/wger/nutrition/static/js/nutrition.js
+++ b/wger/nutrition/static/js/nutrition.js
@@ -71,13 +71,13 @@ function wgerInitIngredientAutocompleter() {
       var ingredientId = suggestion.data.id;
 
       // After clicking on a result set the value of the hidden field
-      $('#id_ingredient').val(ingredientId);
+      $('input[id$="ingredient"]').val(ingredientId);
       $('#exercise_name').html(suggestion.value);
 
       // See if the ingredient has any units and set the values for the forms
       $.get('/api/v2/ingredientweightunit/?ingredient=' + ingredientId, function (unitData) {
         // Remove any old units, if any
-        var options = $('#id_weight_unit').find('option');
+        var options = $('form select[id$="weight_unit"]').find('option');
         $.each(options, function (index, optionObj) {
           if (optionObj.value !== '') {
             $(optionObj).remove();
@@ -89,7 +89,7 @@ function wgerInitIngredientAutocompleter() {
           $.get('/api/v2/weightunit/' + value.unit + '/', function (unit) {
             var unitName = unit.name + ' (' + value.gram + 'g)';
             $('#id_unit').append(new Option(unitName, value.id));
-            $('#id_weight_unit').append(new Option(unitName, value.id));
+            $('form select[id$="weight_unit"]').append(new Option(unitName, value.id));
           });
         });
       });

--- a/wger/nutrition/templates/meal/add.html
+++ b/wger/nutrition/templates/meal/add.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load wger_extras %}
+
+{% block title %}{% trans "Add a new meal" %}{% endblock %}
+
+{% block header %}
+<script type="text/javascript">
+$(document).ready(function() {
+    // Init the autocompleter
+    wgerInitIngredientAutocompleter();
+});
+</script>
+{% endblock %}
+
+{% block content %}
+<form action="{{ form_action }}"
+      method="post"
+      class="form-horizontal">
+    {% csrf_token %}
+    {% render_form_field form.time %}
+    <!-- {{form.ingredient}} -->
+
+    <br>
+    <h4>{% trans "Add a meal item (Optional)" %}</h4>
+
+    {{ meal_item.management_form }}
+    {% for form in meal_item.forms %}
+        {% render_form_errors form %}
+        <div class="form-group {% if field.errors %}has-error{% endif %}" id="form-id_ingredient_searchfield">
+            <label for="id_ingredient_searchfield" class="col-md-3 control-label">
+                {% trans "Ingredient name" %}
+            </label>
+
+            <div class="col-md-9">
+                <input type="text"
+                    id="id_ingredient_searchfield"
+                    name="ingredient_searchfield"
+                    value="{{ingredient_searchfield}}"
+                    class="form-control">
+                <div id="exercise_name"></div>
+            </div>
+        </div>
+        {% for hidden in form.hidden_fields %}
+            {{ hidden }}
+        {% endfor %}
+        {% render_form_field form.amount %}
+        {% render_form_field form.weight_unit %}
+    {% endfor %}
+    {% render_form_submit submit_text %}
+</form>
+{% endblock %}

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -55,7 +55,31 @@ class AddMealTestCase(WorkoutManagerAddTestCase):
 
     object_class = Meal
     url = reverse('nutrition:meal:add', kwargs={'plan_pk': 4})
-    data = {'time': datetime.time(9, 2)}
+    data = {
+        'time': datetime.time(9, 2),
+            'mealitem_set-TOTAL_FORMS': ['1'],
+            'mealitem_set-INITIAL_FORMS': ['0'],
+            'mealitem_set-MIN_NUM_FORMS': ['0'],
+            'mealitem_set-MAX_NUM_FORMS': ['1000'],
+            'ingredient_searchfield': [''],
+            'mealitem_set-0-meal': [''],
+            'mealitem_set-0-ingredient': [''],
+            'mealitem_set-0-id': [''],
+            'mealitem_set-0-weight_unit': [''],
+            'mealitem_set-0-amount': ['']
+        }
+    data_ignore = (
+        'mealitem_set-TOTAL_FORMS',
+            'mealitem_set-INITIAL_FORMS',
+            'mealitem_set-MIN_NUM_FORMS',
+            'mealitem_set-MAX_NUM_FORMS',
+            'ingredient_searchfield',
+            'mealitem_set-0-meal',
+            'mealitem_set-0-ingredient',
+            'mealitem_set-0-id',
+            'mealitem_set-0-weight_unit',
+            'mealitem_set-0-amount'
+    )
     user_success = 'test'
     user_fail = 'admin'
 

--- a/wger/nutrition/views/meal.py
+++ b/wger/nutrition/views/meal.py
@@ -22,8 +22,10 @@ from django.contrib.auth.decorators import login_required
 from django.utils.translation import ugettext_lazy
 
 from django.views.generic import CreateView, UpdateView
+from django.shortcuts import render
 
-from wger.nutrition.models import NutritionPlan, Meal
+from wger.nutrition.forms import MealItemFormSet
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
 from wger.utils.generic_views import WgerFormMixin
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,7 @@ class MealCreateView(WgerFormMixin, CreateView):
     model = Meal
     fields = '__all__'
     title = ugettext_lazy('Add new meal')
+    template_name = 'meal/add.html'
     owner_object = {'pk': 'plan_pk', 'class': NutritionPlan}
 
     def form_valid(self, form):
@@ -48,7 +51,45 @@ class MealCreateView(WgerFormMixin, CreateView):
             NutritionPlan, pk=self.kwargs['plan_pk'], user=self.request.user)
         form.instance.plan = plan
         form.instance.order = 1
-        return super(MealCreateView, self).form_valid(form)
+
+        # Save the meal object
+        self.object = form.save()
+
+        context = self.get_context_data()
+        meal_item_formset = context['meal_item']
+
+        if meal_item_formset.is_valid():
+            # Retrieve form inputs after validating them
+            for meal_item in meal_item_formset:
+                cleaned = meal_item.cleaned_data
+                amount = cleaned.get('amount')
+                weight_unit = cleaned.get('weight_unit')
+                ingredient = cleaned.get('ingredient')
+                # Check for a valid ingredient and amount
+                if amount and ingredient:
+                    meal_item = None
+                    if weight_unit:
+                        meal_item = MealItem(
+                            meal=self.object,
+                            ingredient=ingredient,
+                            weight_unit=weight_unit,
+                            order=1,
+                            amount=amount
+                        )
+                    else:
+                        meal_item = MealItem(
+                            meal=self.object,
+                            ingredient=ingredient,
+                            order=1,
+                            amount=amount
+                        )
+                    meal_item.save()
+                    return HttpResponseRedirect(self.get_success_url())
+                else:
+                    return HttpResponseRedirect(self.get_success_url())
+        else:
+            self.object.delete()
+            return render(self.request, self.template_name, context)
 
     def get_success_url(self):
         return self.object.plan.get_absolute_url()
@@ -56,6 +97,20 @@ class MealCreateView(WgerFormMixin, CreateView):
     # Send some additional data to the template
     def get_context_data(self, **kwargs):
         context = super(MealCreateView, self).get_context_data(**kwargs)
+        
+        if self.request.POST:
+            context['ingredient_searchfield'] = self.request.POST.get(
+                'ingredient_searchfield', ''
+            )
+            if context['ingredient_searchfield'] == '':
+                post_data = self.request.POST.copy()
+                post_data['mealitem_set-0-ingredient'] = ''
+                context['meal_item'] = MealItemFormSet(post_data)
+            else:
+                context['meal_item'] = MealItemFormSet(self.request.POST)
+        else:
+            context['meal_item'] = MealItemFormSet()
+
         context['form_action'] = reverse(
             'nutrition:meal:add', kwargs={'plan_pk': self.kwargs['plan_pk']})
 


### PR DESCRIPTION
#### What does this PR do?
Introduce functionality and UI to add an initial ingredient (optional) when making a new meal in the nutrition plan.

#### Description of Task to be completed?
When the user tries to make a nutrition plan, it is a bit uncomfortable to add a time for the meal and then have to add the food at that meal.
It will be better to set everything at once (time, ingredient and amount).

#### What are the relevant Pivotal Tracker stories?
https://www.pivotaltracker.com/story/show/151629724

#### Screenshots
<img width="593" alt="screen shot 2017-10-18 at 13 21 48" src="https://user-images.githubusercontent.com/31277260/31713771-0d8e9380-b408-11e7-96a7-be9d29b6b74b.png">
