### PR TITLE
feat(exercises): Show all infos for an exercise

### DIFF
--- a/wger/exercises/api/resources.py
+++ b/wger/exercises/api/resources.py
@@ -64,6 +64,44 @@ class ExerciseResource(ModelResource):
         }
 
 
+class ExerciseInfoResource(ModelResource):
+    category = fields.ToOneField('wger.exercises.api.resources'
+                                 '.ExerciseCategoryResource', 'category')
+    muscles = fields.ToManyField('wger.exercises.api.resources'
+                                 '.MuscleResource', 'muscles')
+    muscles_secondary = fields.ToManyField('wger.exercises.api.resources'
+                                           '.MuscleResource',
+                                           'muscles_secondary')
+    comments = fields.ToManyField('wger.exercises.api.resources'
+                                  '.ExerciseCommentResource',
+                                  'exercisecomment_set')
+    images = fields.ToManyField('wger.exercises.api.resources'
+                                '.ExerciseImageResource', 'exerciseimage_set')
+    equipment = fields.ToManyField('wger.exercises.api.resources.'
+                                   'EquipmentResource', 'equipment')
+    language = fields.ToOneField(LanguageResource, 'language')
+    license = fields.ToOneField(LicenseResource, 'license')
+
+    creation_date = fields.DateField(attribute='creation_date', null=True)
+
+    class Meta:
+        queryset = Exercise.objects.all()
+        filtering = {
+            'id': ALL,
+            "uuid": ALL,
+            "category": ALL_WITH_RELATIONS,
+            "creation_date": ALL,
+            "description": ALL,
+            "images": ALL_WITH_RELATIONS,
+            "language": ALL_WITH_RELATIONS,
+            "muscles": ALL_WITH_RELATIONS,
+            "status": ALL,
+            "name": ALL,
+            "license": ALL,
+            "license_author": ALL
+        }
+
+
 class EquipmentResource(ModelResource):
     class Meta:
         queryset = Equipment.objects.all()

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -24,9 +24,19 @@ class ExerciseSerializer(serializers.ModelSerializer):
     '''
     Exercise serializer
     '''
-
+    main_image = serializers.SerializerMethodField()
     class Meta:
         model = Exercise
+
+    def get_main_image(self, obj):       
+        if not obj.main_image:
+            return None
+        else:
+            host = self.context['request'].get_host()
+            url = 'http://' + host + str(obj.main_image.image.url)
+            return url
+
+    
 
 
 class EquipmentSerializer(serializers.ModelSerializer):

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -55,6 +55,7 @@ v1_api.register(exercises_api.ExerciseImageResource())
 v1_api.register(exercises_api.ExerciseResource())
 v1_api.register(exercises_api.MuscleResource())
 v1_api.register(exercises_api.EquipmentResource())
+v1_api.register(exercises_api.ExerciseInfoResource())
 
 v1_api.register(nutrition_api.IngredientResource())
 v1_api.register(nutrition_api.WeightUnitResource())
@@ -138,6 +139,9 @@ router.register(
     base_name='exercisecomment')
 router.register(
     r'muscle', exercises_api_views.MuscleViewSet, base_name='muscle')
+
+router.register(
+    r'exerciseinfo', exercises_api_views.ExerciseInfoReadOnly, base_name='exerciseinfo')
 
 # Nutrition app
 router.register(


### PR DESCRIPTION
**What does this PR do?**
- Add a read-only api endpoint for all exercise info.
- Add exercise image to the read-only endpoint.

**Description of Task to be completed**
This PR adds a new API endpoint that makes available all info of an exercise. The endpoint is read-only, and unlike the exercise info endpoint already there, it includes images for every exercise.

**Background context.**
An endpoint for exercise info is already implemented. The new end point however is different in that its only read only, and includes images for each exercise.

**What are the relevant pivotal tracker stories**
https://www.pivotaltracker.com/n/projects/2116052/stories/151629712
@margierain @emugaya 