### PR TITLE
#151629718 Adding A Relationship Between Workout Logs and Workout Sessions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
-            invoke create-settings --settings-path wger/settings.py 
+            invoke create-settings --settings-path wger/settings.py
+            ./manage.py makemigrations
 
       - save_cache:
           paths:

--- a/wger/manager/models.py
+++ b/wger/manager/models.py
@@ -66,7 +66,7 @@ class Workout(models.Model):
         help_text=_("A short description or goal of the workout. For "
                     "example 'Focus on back' or 'Week 1 of program xy'."))
     user = models.ForeignKey(User, verbose_name=_('User'))
-
+    
     def get_absolute_url(self):
         '''
         Returns the canonical URL to view a workout
@@ -768,7 +768,10 @@ class WorkoutLog(models.Model):
             date = self.date
 
         try:
-            return WorkoutSession.objects.filter(user=self.user).get(date=date)
+            try:
+                return WorkoutSession.objects.filter(user=self.user).get(workout_log=self)
+            except WorkoutSession.DoesNotExist:
+                return WorkoutSession.objects.filter(user=self.user).get(date=date)
         except WorkoutSession.DoesNotExist:
             return None
 
@@ -859,6 +862,9 @@ class WorkoutSession(models.Model):
     '''
     Time the workout session ended
     '''
+
+    workout_log = models.ForeignKey(WorkoutLog, verbose_name=_('Workout Log'), blank=True, null=True)
+
 
     def __str__(self):
         '''

--- a/wger/manager/tests/test_weight_log.py
+++ b/wger/manager/tests/test_weight_log.py
@@ -269,6 +269,7 @@ class WeightlogTestCase(WorkoutManagerTestCase):
         session1.notes = 'Something here'
         session1.impression = '3'
         session1.date = datetime.date(2014, 1, 5)
+        session1.workout_log = l
         session1.save()
 
         session2 = WorkoutSession()
@@ -285,6 +286,7 @@ class WeightlogTestCase(WorkoutManagerTestCase):
         session3.notes = 'The notes here'
         session3.impression = '2'
         session3.date = datetime.date(2014, 1, 5)
+        session3.workout_log = l
         session3.save()
 
         self.assertEqual(l.get_workout_session(), session1)


### PR DESCRIPTION
#### What does this PR do?
Adds a relationship between the models for Workout Log and Workout Session by using a foreign key based on a Workout Log instance id.
Allows for searching by date as a fallback when the workout log is not available when making a new workout session.

#### Description of Task to be completed?
Use a different link between the workout logs and workout sessions other than the date.

#### How should this be manually tested?
Run the test suite `python manage.py test wger/manager/tests/`

Pivotal Tracker story: <https://www.pivotaltracker.com/story/show/151629718>
